### PR TITLE
xispec_peakAnnotHighlight css?

### DIFF
--- a/css/spectrum.css
+++ b/css/spectrum.css
@@ -243,7 +243,7 @@
     font-size:12px;
 }
 .xispec_peakAnnotHighlight{
-    stroke-linecap:round;
+    stroke-linecap: round;
     stroke-linejoin: round;
 }
 .xispec_fragBar{


### PR DESCRIPTION
take the pointy corners off the peak label highlights?